### PR TITLE
Change Highlight Color

### DIFF
--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -50,7 +50,7 @@ class _MessageListState extends State<MessageList> {
                       ], colors: [
                         msg.getTagColor(this._settings, msg.nick),
                         (msg.mentioned || msg.hasKeyword)
-                            ? Color.fromARGB(100, 1, 37, 70)
+                            ? Color.fromARGB(255, 6, 38, 62)
                             : _settings.cardColor
                       ]),
                     ),

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -50,7 +50,7 @@ class _MessageListState extends State<MessageList> {
                       ], colors: [
                         msg.getTagColor(this._settings, msg.nick),
                         (msg.mentioned || msg.hasKeyword)
-                            ? Color.fromARGB(255, 6, 38, 62)
+                            ? Color.fromARGB(255, 0, 37, 71)
                             : _settings.cardColor
                       ]),
                     ),


### PR DESCRIPTION
Changes the highlight color to match the color from this https://github.com/memelabs/chat-gui/blob/master/assets/common.scss
On the left edge of the message box there is still an edge where you can see the underlying message background color though.